### PR TITLE
chore(3drec): `.py` readability fixups

### DIFF
--- a/3drec/my/config.py
+++ b/3drec/my/config.py
@@ -168,7 +168,7 @@ class ConfigMaker():
 
         if max(counts) > 1:
             raise ValueError("verbs repeated in cmd: {}".format(input_list))
-        # by now, there is 1 verb that has occured exactly 1 time
+        # by now, there is 1 verb that has occurred exactly 1 time
         verb = cls.VERBS[presence.index(1)]
         inx = input_list.index(verb)
         return verb, inx

--- a/3drec/my/utils/heartbeat.py
+++ b/3drec/my/utils/heartbeat.py
@@ -1,4 +1,4 @@
-# generates periodic hearbeats for remote expriment monitoring
+# generates periodic heartbeats for remote experiment monitoring
 from pathlib import Path
 import json
 from inspect import stack

--- a/3drec/voxnerf/vox.py
+++ b/3drec/voxnerf/vox.py
@@ -114,7 +114,7 @@ class VoxRF(nn.Module):
         # We notice that DreamFusion also uses an exp scaling on densities.
         # The technique here is developed BEFORE DreamFusion came out,
         # and forms part of our upcoming technical report discussing invariant
-        # scaling for volume rendering. The reseach was presented to our
+        # scaling for volume rendering. The research was presented to our
         # funding agency (TRI) on Aug. 25th, and discussed with a few researcher friends
         # during the period.
         σ = σ * torch.exp(self.d_scale)


### PR DESCRIPTION
Small readability fixups focused on python files in `3drec`. No functional changes.