### PR TITLE
Fix issue `Field required`

### DIFF
--- a/zero123/requirements.txt
+++ b/zero123/requirements.txt
@@ -17,7 +17,7 @@ kornia==0.6
 webdataset==0.2.5
 torchmetrics==0.6.0
 fire==0.4.0
-gradio==3.21.0
+gradio==3.40.1
 diffusers==0.12.1
 datasets[vision]==2.4.0
 carvekit-colab==4.1.0


### PR DESCRIPTION
Issue appear after run `python gradio_new.py`

```
/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py:276: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.1.1/migration/
  client_awake = await self.send_message(event, estimation.dict())
/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/pydantic/main.py:913: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.1.1/migration/
  warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', DeprecationWarning)
/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py:276: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.1.1/migration/
  client_awake = await self.send_message(event, estimation.dict())
/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/pydantic/main.py:913: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.1.1/migration/
  warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', DeprecationWarning)
Task exception was never retrieved
future: <Task finished name='by6xafjz0t_3' coro=<Queue.process_events() done, defined at /home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py:343> exception=1 validation error for PredictBody
event_id
  Field required [type=missing, input_value={'fn_index': 3, 'data': [...ion_hash': 'by6xafjz0t'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1/v/missing>
Traceback (most recent call last):
  File "/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py", line 347, in process_events
    client_awake = await self.gather_event_data(event)
  File "/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py", line 220, in gather_event_data
    data, client_awake = await self.get_message(event, timeout=receive_timeout)
  File "/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/gradio/queueing.py", line 456, in get_message
    return PredictBody(**data), True
  File "/home/lambdasix/anaconda3/envs/zero123/lib/python3.10/site-packages/pydantic/main.py", line 159, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 1 validation error for PredictBody
event_id
  Field required [type=missing, input_value={'fn_index': 3, 'data': [...ion_hash': 'by6xafjz0t'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.1/v/missing
```

## Solution

`pip install gradio==3.40.1`

## Reference

https://github.com/cvlab-columbia/zero123/issues/81